### PR TITLE
Correct null return from mediator

### DIFF
--- a/src/SFA.DAS.Forecasting.Api.UnitTests/Controllers/AccountProjection/WhenGettingExpiringFundsForAnAccount.cs
+++ b/src/SFA.DAS.Forecasting.Api.UnitTests/Controllers/AccountProjection/WhenGettingExpiringFundsForAnAccount.cs
@@ -58,12 +58,7 @@ namespace SFA.DAS.Forecasting.Api.UnitTests.Controllers.AccountProjection
             //Arrange
             _mediator.Setup(x => x.Send(It.Is<GetAccountExpiringFundsQuery>(c => c.AccountId.Equals(ExpectedAccountId)),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new GetAccountExpiringFundsResult
-                {
-                    AccountId = null,
-                    ExpiryAmounts = null,
-                    ProjectionGenerationDate = null
-                });
+                .ReturnsAsync((GetAccountExpiringFundsResult) null);
 
             //Act
             var actual = await _accountProjectionController.GetAccountExpiredFunds(ExpectedAccountId);

--- a/src/SFA.DAS.Forecasting.Api/Controllers/AccountProjectionController.cs
+++ b/src/SFA.DAS.Forecasting.Api/Controllers/AccountProjectionController.cs
@@ -27,7 +27,7 @@ namespace SFA.DAS.Forecasting.Api.Controllers
             {
                 var response = await _mediator.Send(new GetAccountExpiringFundsQuery { AccountId = accountId });
 
-                if (response.ExpiryAmounts == null)
+                if (response == null)
                 {
                     return NotFound();
                 }


### PR DESCRIPTION
The mediator response was returning null for not found, while the
controller was looking for a value within an object. This has been
corrected on the controller to check for a null response